### PR TITLE
Replace TEAM_ID with CLICKUP_TEAM_ID throughout project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Directions for use with Cursor Composer Agent:
 2. Go to Features in settings
 3. Add under MCP Servers:
 ```bash
-npx -y @taazkareem/clickup-mcp-server --env CLICKUP_API_KEY=your_api_key_here --env TEAM_ID=your_team_id_here
+npx -y @taazkareem/clickup-mcp-server --env CLICKUP_API_KEY=your_api_key_here --env CLICKUP_TEAM_ID=your_team_id_here
 ```
 4. Replace the credentials and click Save
 5. Use Natural Language to interact with your ClickUp Workspace!

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,26 +1,24 @@
-// Parse command line arguments for --env flags
 const args = process.argv.slice(2);
 const envArgs: { [key: string]: string } = {};
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--env' && i + 1 < args.length) {
     const [key, value] = args[i + 1].split('=');
     if (key === 'CLICKUP_API_KEY') envArgs.clickupApiKey = value;
-    if (key === 'TEAM_ID') envArgs.teamId = value;
-    i++; // Skip the next argument since we used it
+    if (key === 'CLICKUP_TEAM_ID') envArgs.clickupTeamId = value;
+    i++;
   }
 }
 
 interface Config {
   clickupApiKey: string;
-  teamId: string;
+  clickupTeamId: string;
 }
 
 const configuration: Config = {
   clickupApiKey: envArgs.clickupApiKey || '',
-  teamId: envArgs.teamId || '',
+  clickupTeamId: envArgs.clickupTeamId || '',
 };
 
-// Check for missing environment variables
 const missingEnvVars = Object.entries(configuration)
   .filter(([_, value]) => !value)
   .map(([key]) => key);
@@ -31,4 +29,4 @@ if (missingEnvVars.length > 0) {
   );
 }
 
-export default configuration; 
+export default configuration;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ import {
 } from "./types/clickup.js";
 
 // Initialize ClickUp service
-const clickup = ClickUpService.initialize(config.clickupApiKey, config.teamId);
+const clickup = ClickUpService.initialize(config.clickupApiKey, config.clickupTeamId);
 
 /**
  * Create an MCP server with capabilities for tools and prompts.
@@ -981,7 +981,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
   try {
     switch (request.params.name) {
       case "summarize_tasks": {
-        const spaces = await clickup.getSpaces(config.teamId);
+        const spaces = await clickup.getSpaces(config.clickupTeamId);
         const tasks = [];
 
         // Gather all tasks
@@ -1025,7 +1025,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
       }
 
       case "analyze_priorities": {
-        const spaces = await clickup.getSpaces(config.teamId);
+        const spaces = await clickup.getSpaces(config.clickupTeamId);
         const tasks = [];
 
         for (const space of spaces) {

--- a/src/services/clickup.ts
+++ b/src/services/clickup.ts
@@ -21,11 +21,11 @@ import {
 export class ClickUpService {
   private client: AxiosInstance;
   private static instance: ClickUpService;
-  private teamId: string;
+  private clickupTeamId: string;
   private rateLimitRemaining: number = 100; // Default to lowest tier limit
   private rateLimitReset: number = 0;
 
-  private constructor(apiKey: string, teamId: string) {
+  private constructor(apiKey: string, clickupTeamId: string) {
     this.client = axios.create({
       baseURL: 'https://api.clickup.com/api/v2',
       headers: {
@@ -59,7 +59,7 @@ export class ClickUpService {
       }
     );
 
-    this.teamId = teamId;
+    this.clickupTeamId = clickupTeamId;
   }
 
   /**
@@ -99,13 +99,13 @@ export class ClickUpService {
   /**
    * Initializes the ClickUpService singleton instance.
    * @param apiKey - The ClickUp API key for authentication
-   * @param teamId - The team/workspace ID to operate on
+   * @param clickupTeamId - The team/workspace ID to operate on
    * @returns The singleton instance of ClickUpService
    * @throws Error if initialization fails
    */
-  public static initialize(apiKey: string, teamId: string): ClickUpService {
+  public static initialize(apiKey: string, clickupTeamId: string): ClickUpService {
     if (!ClickUpService.instance) {
-      ClickUpService.instance = new ClickUpService(apiKey, teamId);
+      ClickUpService.instance = new ClickUpService(apiKey, clickupTeamId);
     }
     return ClickUpService.instance;
   }
@@ -288,13 +288,13 @@ export class ClickUpService {
 
   /**
    * Gets all lists in the workspace.
-   * @param teamId - ID of the team/workspace
+   * @param clickupTeamId - ID of the team/workspace
    * @returns Promise resolving to array of ClickUpList objects
    * @throws Error if the API request fails
    */
-  async getAllLists(teamId: string): Promise<ClickUpList[]> {
+  async getAllLists(clickupTeamId: string): Promise<ClickUpList[]> {
     return this.makeRequest(async () => {
-      const response = await this.client.get(`/team/${teamId}/list`);
+      const response = await this.client.get(`/team/${clickupTeamId}/list`);
       return response.data.lists;
     });
   }
@@ -313,9 +313,9 @@ export class ClickUpService {
   }
 
   // Spaces
-  async getSpaces(teamId: string): Promise<ClickUpSpace[]> {
+  async getSpaces(clickupTeamId: string): Promise<ClickUpSpace[]> {
     return this.makeRequest(async () => {
-      const response = await this.client.get(`/team/${teamId}/space`);
+      const response = await this.client.get(`/team/${clickupTeamId}/space`);
       return response.data.spaces;
     });
   }
@@ -327,8 +327,8 @@ export class ClickUpService {
     });
   }
 
-  async findSpaceByName(teamId: string, spaceName: string): Promise<ClickUpSpace | null> {
-    const spaces = await this.getSpaces(teamId);
+  async findSpaceByName(clickupTeamId: string, spaceName: string): Promise<ClickUpSpace | null> {
+    const spaces = await this.getSpaces(clickupTeamId);
     return spaces.find(space => space.name.toLowerCase() === spaceName.toLowerCase()) || null;
   }
 
@@ -520,7 +520,7 @@ export class ClickUpService {
 
   async findListByNameGlobally(listName: string): Promise<ClickUpList | null> {
     // First try the direct lists
-    const lists = await this.getAllLists(this.teamId);
+    const lists = await this.getAllLists(this.clickupTeamId);
     const directList = lists.find(list => list.name.toLowerCase() === listName.toLowerCase());
     if (directList) return directList;
 
@@ -550,9 +550,9 @@ export class ClickUpService {
    * @throws Error if API requests fail
    */
   async getWorkspaceHierarchy(): Promise<WorkspaceTree> {
-    const spaces = await this.getSpaces(this.teamId);
+    const spaces = await this.getSpaces(this.clickupTeamId);
     const root: WorkspaceTree['root'] = {
-      id: this.teamId,
+      id: this.clickupTeamId,
       name: 'Workspace',
       type: 'workspace',
       children: []


### PR DESCRIPTION
Replace `TEAM_ID` with `CLICKUP_TEAM_ID` throughout the project.

* **README.md**
  - Replace `TEAM_ID` with `CLICKUP_TEAM_ID` in the Quick Start section.

* **src/config.ts**
  - Replace `TEAM_ID` with `CLICKUP_TEAM_ID` in the environment variable parsing.
  - Replace `teamId` with `clickupTeamId` in the `Config` interface.
  - Replace `teamId` with `clickupTeamId` in the `configuration` object.

* **src/index.ts**
  - Replace `config.teamId` with `config.clickupTeamId` in the `clickup` initialization.
  - Replace `config.teamId` with `config.clickupTeamId` in the `GetPromptRequestSchema` handler.

* **src/services/clickup.ts**
  - Replace `this.teamId` with `this.clickupTeamId` in the constructor.
  - Replace `teamId` with `clickupTeamId` in the `initialize` method.
  - Replace `teamId` with `clickupTeamId` in the `getSpaces` method.
  - Replace `teamId` with `clickupTeamId` in the `getAllLists` method.
  - Replace `teamId` with `clickupTeamId` in the `getWorkspaceHierarchy` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikepsinn/clickup-mcp-server/pull/1?shareId=3c996e55-f5ce-4189-91fe-8de332bbe24a).